### PR TITLE
Fix to compile with scala-2.11

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
+


### PR DESCRIPTION
Current master can't be published because of
```
 value zipWith is not a member of scala.concurrent.Future[scala.util.Either[L,R]]
```
My mistake, `zipWith` was introduced only in scala-2.12, reimplemented it to be compatible with scala-2.11.