### PR TITLE
Add tap

### DIFF
--- a/src/main/scala/com/evolutiongaming/util/Tap.scala
+++ b/src/main/scala/com/evolutiongaming/util/Tap.scala
@@ -1,0 +1,32 @@
+package com.evolutiongaming.util
+
+/**
+  * Purpose of `tap` method is to perform operations on intermediate results within a method chain.
+  *
+  * (1 to 10)
+  *   .tap { x => println(s"original: $x") }
+  *   .filter { _ % 2 == 0 }
+  *   .tap { x => println(s"evens: $x") }
+  *   .map { x => x * x }
+  *   .tap { x => println(s"squares: $x") }
+  *
+  * What used to be
+  *
+  *   def stackTraceAsString(cause: Throwable): String = {
+  *     val out = new StringWriter()
+  *     cause.printStackTrace(new PrintWriter(out))
+  *     out.toString
+  *   }
+  *
+  * becomes
+  *
+  *   def stackTraceAsString(cause: Throwable): String =
+  *     new StringWriter() tap { out => cause.printStackTrace(new PrintWriter(out)) } toString
+  *
+  */
+
+object Tap {
+  implicit class Ops[A](val a: A) extends AnyVal {
+    def tap(f: A => Unit): A = { f(a); a }
+  }
+}

--- a/src/test/scala/com/evolutiongaming/util/TapSpec.scala
+++ b/src/test/scala/com/evolutiongaming/util/TapSpec.scala
@@ -1,0 +1,14 @@
+package com.evolutiongaming.util
+
+import com.evolutiongaming.util.Tap._
+import org.scalatest.{FunSuite, Matchers}
+
+class TapSpec extends FunSuite with Matchers {
+  test("apply function to itself") {
+    0 tap { _ shouldEqual 0 }
+  }
+
+  test("returns itself after function application") {
+    0 tap { _ => } shouldEqual 0
+  }
+}


### PR DESCRIPTION
Purpose of `tap` method is to perform operations on intermediate results within a method chain.

```scala
(1 to 10)
  .tap { x => println(s"original: $x") }
  .filter { _ % 2 == 0 }
  .tap { x => println(s"evens: $x") }
  .map { x => x * x }
  .tap { x => println(s"squares: $x") }
```

What used to be

```scala
def stackTraceAsString(cause: Throwable): String = {
  val out = new StringWriter()
  cause.printStackTrace(new PrintWriter(out))
  out.toString
}
```

becomes

```scala
def stackTraceAsString(cause: Throwable): String =
  new StringWriter() tap { out => cause.printStackTrace(new PrintWriter(out)) } toString
```
