### PR TITLE
add let, |>

### DIFF
--- a/src/main/scala/com/evolutiongaming/util/Tap.scala
+++ b/src/main/scala/com/evolutiongaming/util/Tap.scala
@@ -23,10 +23,34 @@ package com.evolutiongaming.util
   *   def stackTraceAsString(cause: Throwable): String =
   *     new StringWriter() tap { out => cause.printStackTrace(new PrintWriter(out)) } toString
   *
+  *
+  * Purpose of `let` and `|>` methods to evolve an operation within a method chain.
+  *
+  * What used to be
+  *
+  *   f1(f2(f3(a)))
+  *
+  * becomes
+  *
+  *   a |> f3 |> f2 |> f1
+  *
+  * What used to be
+  *
+  *   system.settings.config.getConfig("company.http.client")
+  *     .withFallback(system.settings.config.getConfig("akka.http.client"))
+  *
+  * becomes
+  *
+  *   (system.settings.config.getConfig _).let { config =>
+  *     config("company.http.client") withFallback config("akka.http.client")
+  *   }
+  *
   */
 
 object Tap {
   implicit class Ops[A](val a: A) extends AnyVal {
     def tap(f: A => Unit): A = { f(a); a }
+    def let[B](f: A => B): B = f(a)
+    def |>[B](f: A => B): B = f(a)
   }
 }

--- a/src/test/scala/com/evolutiongaming/util/TapSpec.scala
+++ b/src/test/scala/com/evolutiongaming/util/TapSpec.scala
@@ -4,11 +4,18 @@ import com.evolutiongaming.util.Tap._
 import org.scalatest.{FunSuite, Matchers}
 
 class TapSpec extends FunSuite with Matchers {
-  test("apply function to itself") {
+  test("tap") {
     0 tap { _ shouldEqual 0 }
+    0 tap { _ => } shouldEqual 0
   }
 
-  test("returns itself after function application") {
-    0 tap { _ => } shouldEqual 0
+  test("let") {
+    0 let { _ shouldEqual 0 }
+    0 let { _ + 1 } shouldEqual 1
+  }
+
+  test("|>") {
+    0 |> { _ shouldEqual 0 }
+    0 |> { _ + 1 } shouldEqual 1
   }
 }


### PR DESCRIPTION
#### Purpose of `let` and `|>` methods to evolve an operation within a method chain.
What used to be
```scala
  f1(f2(f3(a)))
```
becomes
```scala
  a |> f3 |> f2 |> f1
```
What used to be
```scala
  system.settings.config.getConfig("company.http.client")
    .withFallback(system.settings.config.getConfig("akka.http.client"))
```
becomes
```scala
  (system.settings.config.getConfig _).let { config =>
    config("company.http.client") withFallback config("akka.http.client")
  }
```
